### PR TITLE
Remove the automatic cgo flags

### DIFF
--- a/fdkaac/dec.go
+++ b/fdkaac/dec.go
@@ -23,8 +23,6 @@
 package fdkaac
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/../fdk-aac-lib/objs/include/fdk-aac
-#cgo LDFLAGS: ${SRCDIR}/../fdk-aac-lib/objs/lib/libfdk-aac.a
 #include "aacdecoder_lib.h"
 
 typedef struct {

--- a/fdkaac/enc.go
+++ b/fdkaac/enc.go
@@ -23,8 +23,6 @@
 package fdkaac
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/../fdk-aac-lib/objs/include/fdk-aac
-#cgo LDFLAGS: ${SRCDIR}/../fdk-aac-lib/objs/lib/libfdk-aac.a
 #include "aacenc_lib.h"
 
 typedef struct {


### PR DESCRIPTION
This PR removes the CGO flags embedded in the code, to allow the user to change them as necessary.